### PR TITLE
Fix typo in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,4 +128,4 @@ To run tests
 
 ::
 
-    python manage.py test pyhio
+    python manage.py test pyohio


### PR DESCRIPTION
As simple as the title. `python manage.py test pyohio` was typoed as `python manage.py test pyhio`.