### PR TITLE
Update `CONFERENCE_ID` in local and test settings

### DIFF
--- a/pyohio/settings/local.py.example
+++ b/pyohio/settings/local.py.example
@@ -1,5 +1,10 @@
 from .dev import *
 
+# Set conference_id to 1 locally, since the value of 2 set in base.py does not exist
+# in our fixtures. If we don't set this to a value that exists, we get some confusing
+# query errors, both in test, and when loading pages.
+CONFERENCE_ID = 1
+
 # Uncomment to install debug_toolbar
 #INSTALLED_APPS.append('debug_toolbar')
 #MIDDLEWARE_CLASSES.append('debug_toolbar.middleware.DebugToolbarMiddleware')

--- a/pyohio/settings/test.py
+++ b/pyohio/settings/test.py
@@ -22,6 +22,9 @@ SECRET_KEY = env_or_default('SECRET_KEY', u'dipps!+sq49#e2k#5^@4*^qn#8s83$kawqqx
 # with its current schema
 SOUTH_TESTS_MIGRATE = False
 
+# Set conference_id to 1, since we're testing against fixtures.
+CONFERENCE_ID = 1
+
 # Using sqlite in memory speeds things up even more, but that's getting
 # pretty far from production. I don't think it's worth the risk.
 # DATABASES = {

--- a/pyohio/tests/test_homepage.py
+++ b/pyohio/tests/test_homepage.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+
+
+class HomepageTestCase(TestCase):
+    fixtures = [
+        'fixtures/conference.json',
+        'fixtures/initial_data.json',
+        'fixtures/proposal_base.json',
+        'fixtures/sitetree.json',
+        'fixtures/sponsor_benefits.json',
+        'fixtures/sponsor_levels.json'
+    ]
+
+    # Sanity check. Spectacularly fails with a vague Sitetree error if
+    # CONFERENCE_ID is not set properly.
+    def test_homepage_response_code(self):
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Closes pyohio/pyohio#37 by updating local.py.example and test.py to use a `CONFERENCE_ID` that exists in the fixtures. Includes a simple test that will fail if `CONFERENCE_ID` is set incorrectly, albeit with a very vague and confusing error message:

```
======================================================================
ERROR: test_homepage_response_code (pyohio.tests.test_homepage.HomepageTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/anthony/pykl/pyohio/pyohio/tests/test_homepage.py", line 33, in test_homepage_response_code
    response = self.client.get('/')
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/test/client.py", line 473, in get
    response = super(Client, self).get(path, data=data, **extra)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/test/client.py", line 280, in get
    return self.request(**r)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/test/client.py", line 426, in request
    response = self.handler(environ)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/test/client.py", line 109, in __call__
    response = self.get_response(request)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/core/handlers/base.py", line 196, in get_response
    response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/core/handlers/base.py", line 238, in handle_uncaught_exception
    return callback(request, **param_dict)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/utils/decorators.py", line 99, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/views/defaults.py", line 46, in server_error
    return http.HttpResponseServerError(template.render(Context({})))
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/base.py", line 140, in render
    return self._render(context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/test/utils.py", line 85, in instrumented_test_render
    return self.nodelist.render(context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/base.py", line 840, in render
    bit = self.render_node(node, context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/debug.py", line 78, in render_node
    return node.render(context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/loader_tags.py", line 123, in render
    return compiled_parent._render(context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/test/utils.py", line 85, in instrumented_test_render
    return self.nodelist.render(context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/base.py", line 840, in render
    bit = self.render_node(node, context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/debug.py", line 78, in render_node
    return node.render(context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/loader_tags.py", line 62, in render
    result = block.nodelist.render(context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/base.py", line 840, in render
    bit = self.render_node(node, context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/debug.py", line 78, in render_node
    return node.render(context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/loader_tags.py", line 62, in render
    result = block.nodelist.render(context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/base.py", line 840, in render
    bit = self.render_node(node, context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/debug.py", line 78, in render_node
    return node.render(context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/loader_tags.py", line 62, in render
    result = block.nodelist.render(context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/base.py", line 840, in render
    bit = self.render_node(node, context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/django/template/debug.py", line 78, in render_node
    return node.render(context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/sitetree/templatetags/sitetree.py", line 221, in render
    tree_items = sitetree.menu(self.tree_alias, self.tree_branches, context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/sitetree/sitetreeapp.py", line 565, in menu
    tree_alias, sitetree_items = self.init_tree(tree_alias, context)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/sitetree/sitetreeapp.py", line 532, in init_tree
    tree_alias, sitetree_items = self.get_sitetree(tree_alias)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/sitetree/sitetreeapp.py", line 404, in get_sitetree
    self.get_tree_current_item(alias)
  File "/Users/anthony/.virtualenvs/pyohio/lib/python2.7/site-packages/sitetree/sitetreeapp.py", line 437, in get_tree_current_item
    raise SiteTreeError('Sitetree needs "django.core.context_processors.request" to be in TEMPLATE_CONTEXT_PROCESSORS in your settings file. If it is, check that your view pushes request data into the template.')
SiteTreeError: Sitetree needs "django.core.context_processors.request" to be in TEMPLATE_CONTEXT_PROCESSORS in your settings file. If it is, check that your view pushes request data into the template.

----------------------------------------------------------------------
Ran 1 test in 0.189s

FAILED (errors=1)
Destroying test database for alias 'default'...
```

In this case, it appears that `TEMPLATE_CONTEXT_PROCESSORS` is set incorrectly, when the root of the issue is an incorrect `CONFERENCE_ID` setting. This may or may not have led me on a goose chase. :disappointed: 

I opted to keep the notes about making sure to set the value in a comment in the settings file itself, as that seemed like the most reasonable place to put it.