### PR TITLE
Display sponsor even if no website_logo is set

### DIFF
--- a/pyohio/templates/sponsorship/list.html
+++ b/pyohio/templates/sponsorship/list.html
@@ -22,13 +22,16 @@
       <h3>{{ level.name }} Sponsors</h3>
 
       {% for sponsor in level.sponsors %}
-        {% if sponsor.website_logo %}
         <div class="media">
           <div class="media-image pull-left">
+          {% if sponsor.website_logo %}
             {% if sponsor.external_url %}<a href="{{ sponsor.external_url }}">{% endif %}
               <img src="{% thumbnail sponsor.website_logo "150x80" %}"
                       alt="{{ sponsor.name }}" />
             {% if sponsor.external_url %}</a>{% endif %}
+          {% else %}
+            <p>&nbsp;</p>
+          {% endif %}
           </div>
           <div class="media-body">
             <h4 class="media-heading">{{ sponsor.name }}</h4>
@@ -40,7 +43,6 @@
             {% endif %}
           </div>
         </div>
-        {% endif %}
       {% endfor %}
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
I'd like the logo/avatar/headshot to be optional for Individual sponsors but the template as-is will only list sponsors if they have a website_logo set. This change will cause the sponsor to be displayed whether they have a website_logo or not and it preserves formatting for those that don't.