### PR TITLE
downgrade django-mailer to 1.0 to be compatible with Django 1.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 
 # Django packages
 Django==1.6.2
-django-mailer==1.1
+django-mailer==1.0
 django-redis-cache==0.9.7
 metron==0.1 # 0.2.dev3
 #pinax-utils==1.0b1.dev3


### PR DESCRIPTION
django-mailer >1.0 is incompatible with South versions <1.0. Since the pyohio repo is running on Django 1.6 and is using a version of South <1.0, django-mailer needs to be downgraded in order for migrations to run without errors.